### PR TITLE
Changes from SPTK v3.11 release

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Change log
 v0.1.10 <2018-xx-xx>
 --------------------
 
+- `#54`_: Changes from SPTK v3.11 release. 6 and 7 pade approximatino in lmadf and mlsadf is now supported,
+
 v0.1.9 <2018-01-01>
 -------------------
 
@@ -91,3 +93,5 @@ v0.1.0 <2015-09-05>
 -------------------
 
 -  Initial release
+
+.. _#54: https://github.com/r9y9/pysptk/pull/54

--- a/pysptk/util.py
+++ b/pysptk/util.py
@@ -100,8 +100,9 @@ def assert_gamma(gamma):
 
 
 def assert_pade(pade):
-    if pade != 4 and pade != 5:
-        raise ValueError("4 or 5 pade approximation is supported")
+    valid = [4, 5, 6, 7]
+    if pade not in valid:
+        raise ValueError("4, 5, 6 or 7 pade approximation is supported")
 
 
 def assert_stage(stage):

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -25,7 +25,7 @@ def test_acep():
 
     # invalid pade
     yield raises(ValueError)(__test), 20, 3
-    yield raises(ValueError)(__test), 20, 6
+    yield raises(ValueError)(__test), 20, 8
 
 
 def test_agcep():
@@ -58,4 +58,4 @@ def test_amcep():
 
     # invalid pade
     yield raises(ValueError)(__test), 20, 0.35, 3
-    yield raises(ValueError)(__test), 20, 0.35, 6
+    yield raises(ValueError)(__test), 20, 0.35, 8

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -42,17 +42,18 @@ def test_LMADF():
         y = synthesizer.synthesis(source, b)
         assert np.all(np.isfinite(y))
 
-    def __test(order):
-        __test_synthesis(LMADF(order))
+    def __test(order, pd):
+        __test_synthesis(LMADF(order, pd=pd))
 
-    for order in [20, 25]:
-        yield __test, order
+    for pd in [4, 5, 6, 7]:
+        for order in [20, 25]:
+            yield __test, order, pd
 
     def __test_invalid_pade(pd):
         LMADF(20, pd=pd)
 
     yield raises(ValueError)(__test_invalid_pade), 3
-    yield raises(ValueError)(__test_invalid_pade), 6
+    yield raises(ValueError)(__test_invalid_pade), 8
 
 
 def test_MLSADF():
@@ -76,18 +77,19 @@ def test_MLSADF():
 
     from pysptk.synthesis import MLSADF
 
-    def __test(order, alpha):
-        __test_synthesis(MLSADF(order, alpha))
+    def __test(order, alpha, pd):
+        __test_synthesis(MLSADF(order, alpha, pd=pd))
 
-    for order in [20, 25]:
-        for alpha in [0.0, 0.41]:
-            yield __test, order, alpha
+    for pd in [4, 5, 6, 7]:
+        for order in [20, 25]:
+            for alpha in [0.0, 0.41]:
+                yield __test, order, alpha, pd
 
     def __test_invalid_pade(pd):
         MLSADF(20, pd=pd)
 
     yield raises(ValueError)(__test_invalid_pade), 3
-    yield raises(ValueError)(__test_invalid_pade), 6
+    yield raises(ValueError)(__test_invalid_pade), 8
 
 
 def test_MGLSADF():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,7 @@ def test_assert_pade():
     def __test(pade):
         pysptk.util.assert_pade(pade)
 
-    for pade in [3, 6]:
+    for pade in [3, 8]:
         yield raises(ValueError)(__test), pade
 
 


### PR DESCRIPTION
6 and 7 pade approximation in lmadf and mlsadf is now supported

Ref: https://github.com/r9y9/SPTK/pull/23