### PR TITLE
Restrict Cython version to <3.0.0

### DIFF
--- a/.requirements.txt
+++ b/.requirements.txt
@@ -1,4 +1,4 @@
 numpy >= 1.20.0
-cython >= 0.21.0
+cython >= 0.21.0, <= 0.29.36
 numpydoc
 pysptk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "wheel",
     "setuptools",
-    "cython>=0.28.0",
+    "cython>=0.28.0,<3.0.0", # Cython 3.0.0 causes #95
     "numpy>=v1.20.0",
     "scipy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "wheel",
     "setuptools",
-    "cython>=0.28.0,<=0.28.36", # Cython 3.0.0 causes #95
+    "cython>=0.28.0,<=0.29.36", # Cython 3.0.0 causes #95
     "numpy>=v1.20.0",
     "scipy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "wheel",
     "setuptools",
-    "cython>=0.28.0,<3.0.0", # Cython 3.0.0 causes #95
+    "cython>=0.28.0,<=0.28.36", # Cython 3.0.0 causes #95
     "numpy>=v1.20.0",
     "scipy",
 ]


### PR DESCRIPTION
Testing:

This workaround works:
```
pip install --upgrade Cython==0.29.36
pip install pysptk --no-build-isolation
```

But would rather not have to rely on --no-build-isolation flag when installing this dependency in my project.
