### PR TITLE
Update cython version

### DIFF
--- a/.requirements.txt
+++ b/.requirements.txt
@@ -1,4 +1,4 @@
 numpy >= 1.20.0
-cython >= 0.21.0
+cython ==0.29.36
 numpydoc
 pysptk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "wheel",
     "setuptools",
-    "cython>=0.28.0",
+    "cython==0.29.36",
     "numpy>=v1.20.0",
     "scipy",
 ]


### PR DESCRIPTION
Since July 17th, there is an error raised when installing pysptk using pip, this is due to the newly released cython version. Limiting the version of cython to 0.29.36 can help solve this problem. Local test passed.